### PR TITLE
Ben import tool

### DIFF
--- a/bin/import
+++ b/bin/import
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+var mysql 		= require('mysql');
+var readline 	= require('readline');
+var mongoose 	= require('mongoose');
+var async 		= require('async');
+var _					= require('lodash');
+var argv 			= require('minimist')(process.argv.slice(2));
+require('dotenv').config();
+
+
+if (argv.hasOwnProperty('help')) {
+	console.log('Import legacy data from mysql to mongo.');
+	console.log('Required flags: --database --user --pass');
+	console.log('Optional flags: --host=localhost');
+	return;
+}
+
+// make sure we have the arguments we need
+if (!argv.hasOwnProperty('database')) {
+	console.error('Please pass in the database name with --database');
+	return;
+}
+if (!argv.hasOwnProperty('user')) {
+	console.error('Please pass in the mysql user name with --user');
+	return;
+}
+if (!argv.hasOwnProperty('pass')) {
+	console.error('Please pass in the mysql password with --pass');
+	return;
+}
+
+// create the stdin interface
+rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout
+});
+
+// warn for import
+rl.question('Ready to clear your Songs and Tags collections in your mongo db? (y/n): ', function(answer){
+
+	// don't need to read anything else
+	rl.close();
+
+	// if no
+	if (answer.toLowerCase().charAt(0) == 'n') {
+		return;
+	}
+
+	// get mysql database name (change to use config?)
+	var dbName = process.argv[2];
+	console.log('Importing ' + dbName);
+
+	// Create connection to mysql db
+	var legacy = mysql.createConnection({
+	  host     : argv.host || 'localhost',
+	  user     : argv.user,
+	  password : argv.pass,
+	  database : argv.database
+	});
+	legacy.connect();
+
+	// Create connection to mongo db
+	mongoose.connect(process.env.MONGODB_URI);
+
+	// get Songs model
+	var Song = require('../models/songs');
+
+	// clear out collection
+	return Song.remove({}, function(){
+		console.log('Songs collection has been emptied');
+
+		// query for song data from mysql
+		// no promises support :(
+		legacy.query("SELECT id as legacyId, \
+									CONVERT(IsActive, UNSIGNED) as active, \
+									Title as title, \
+									Artist as author, \
+									Scripture as scripture, \
+									LyricsExcerpt as lyrics, \
+									Notes as notes, \
+									Quarantined as quarantined \
+									FROM songs", 
+									function(err, songs){
+
+			// this is a control flow to allow for async things to happen in series
+			// first we loop over the songs and add tags and links to each songs from the 
+			// legacy db (done in the async.eachSeries) then we will bulk insert the songs
+			// into our mongo collection. Last we will clear out and import tags.
+			async.waterfall([
+				/* BEGIN FIRST WATERFALL METHOD */
+				function(callback) {
+					//loop over rows and get tags and attachments
+					async.eachSeries(songs, 
+						// this method is called on each row
+						function(song, cb){
+							// get tags
+							legacy.query("SELECT t.name as tag, tt.name as tagGroup \
+														FROM tags t \
+														JOIN songs_tags st \
+															ON st.tag_id = t.id \
+														LEFT JOIN tags_tagtypes tty \
+															ON tty.tag_id = t.id \
+														LEFT JOIN tagtypes tt \
+															ON tty.tagtype_id = tt.id \
+														WHERE st.song_id = ?", 
+														[song.legacyId], 
+														function(err, tags){
+								// transform normalized tags into our tagGroup schema
+								var tagGroups = _.map(_.groupBy(tags, 'tagGroup'), function(val, key){
+									// _.map allows us to transform the results of each grouping
+									return { 
+										// grouping put groupless tags in the "undefined" group
+										name: (key == "undefined") ? undefined : key,
+										// pluck all of the tag values out of the objects in the group
+										tags: _.map(val, 'tag')
+									}
+								});
+
+								// assign tagGroups array to song
+								song.tagGroups = tagGroups;
+								
+								// get attachments
+								legacy.query("SELECT Name as name, Url as url \
+															FROM attachments a \
+															JOIN attachments_songs ats \
+																ON ats.attachment_id = a.id \
+															WHERE ats.song_id = ?", 
+															[song.legacyId],
+															function(err, attachments){
+									// add attachments as is to song, array of objects is what we want
+									song.links = attachments;
+									return cb();
+
+								});
+							});
+						},
+						// this method is called when all rows have been looped over
+						function() {
+							// move on to the next method in async.waterfall
+							return callback(null);
+						}
+					);
+				},
+				/* BEGIN SECOND WATERFALL METHOD */
+				function(callback) {
+					// insert songs to mongo db collection
+					console.log('Importing ' + songs.length + ' songs');
+					Song.create(songs, function(err, mongoSongs){
+						if (err) {
+							console.log('There was an error inserting songs into the mongo collection');
+							return callback(err);
+						}
+
+						console.log(mongoSongs.length + ' songs have been imported');
+						// all done with waterfall
+						return callback(null);
+					});
+				},
+				/* BEGIN THIRD WATERFALL METHOD */
+				function(callback) {
+					// import tags
+					var TagGroup = require('../models/tagGroup');
+
+					TagGroup.remove({}, function(){
+						console.log('TagGroup collection has been emptied');
+						legacy.query("SELECT t.name as tag, tt.name as tagGroup \
+													FROM tags t \
+													LEFT JOIN tags_tagtypes tty \
+														ON tty.tag_id = t.id \
+													LEFT JOIN tagtypes tt \
+														ON tty.tagtype_id = tt.id",
+														function(err, tags){
+							// transform normalized tags into our tagGroup schema
+							var tagGroups = _.map(_.groupBy(tags, 'tagGroup'), function(val, key){
+								// _.map allows us to transform the results of each grouping
+								return { 
+									// grouping put groupless tags in the "undefined" group
+									name: (key == "null") ? undefined : key,
+									// pluck all of the tag values out of the objects in the group
+									tags: _.map(val, 'tag')
+								}
+							});
+
+							// bulk insert of denormalized tag groups
+							TagGroup.create(tagGroups, function(err, mongoTagGroups){
+								if (err) {
+									console.log('There was an error inserting tagGroups into the mongo collection');
+									return callback(err);
+								}
+
+								console.log(mongoTagGroups.length + ' tagGroups have been imported');
+
+								return callback(null);
+							});
+						});
+
+					});
+				}
+	
+			], function(err){
+				// close up shop
+				if (err){ console.log(err); }
+				legacy.end();
+				mongoose.connection.close();
+				return;
+			});
+
+		});
+
+	});
+});
+
+
+
+
+

--- a/models/songs.js
+++ b/models/songs.js
@@ -1,13 +1,24 @@
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
+var linkSchema = new Schema({
+	name: String,
+	url: String
+});
+
+var tagGroupSchema = require('./tagGroup.schema');
+
 var songSchema = new Schema({
   title: String,
   author: String,
   lyrics: String,
   notes: String,
+  scripture: String,
   quarantined: Boolean,
-  links: [String]
+  active: Boolean,
+  legacyId: Number,
+  links: [linkSchema],
+  tagGroups: [tagGroupSchema]
 });
 
 var Song = mongoose.model('Song', songSchema);

--- a/models/tagGroup.js
+++ b/models/tagGroup.js
@@ -1,0 +1,7 @@
+var mongoose = require('mongoose');
+
+var tagGroupSchema = require('./tagGroup.schema');
+
+var TagGroup = mongoose.model('TagGroup', tagGroupSchema);
+
+module.exports = TagGroup;

--- a/models/tagGroup.schema.js
+++ b/models/tagGroup.schema.js
@@ -1,0 +1,9 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var tagGroupSchema = new Schema({
+	name: String,
+	tags: [String]
+});
+
+module.exports = tagGroupSchema;

--- a/package.json
+++ b/package.json
@@ -6,18 +6,21 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "async": "^2.0.1",
     "body-parser": "~1.15.1",
     "cookie-parser": "~1.4.3",
     "debug": "~2.2.0",
     "dotenv": "^2.0.0",
     "express": "~4.13.4",
     "jade": "~1.11.0",
+    "lodash": "^4.14.0",
     "mongoose": "^4.5.5",
     "morgan": "~1.7.0",
     "nunjucks": "^2.4.2",
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
+    "minimist": "^1.2.0",
     "mysql": "^2.11.1"
   },
   "engines": {


### PR DESCRIPTION
Closes #5. Import tool is complete and will clear out the `songs` and `taggroup` mongo collections and import from the legacy db. Can be run as follows from project room

`bin/import --database=musictable_php --user=user --pass=pass [--host=localhost]`

There are also a handful of changes/additions to the models to accomodate the import. Hopefully the import script isn't too confusing to read, the async/callback nature of node makes it a bit more complex than it needs to be, and the mysql module doesn't support Promises to make the code more organized.
