### PR TITLE
Sass workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ jspm_packages
 # Environment
 /*.env
 
+# We don't commit CSS, only SASS
+public/css/*.css

--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
   "dependencies": {
     "async": "^2.0.1",
     "body-parser": "~1.15.1",
+    "bootstrap-sass": "^3.3.7",
     "cookie-parser": "~1.4.3",
     "debug": "~2.2.0",
     "dotenv": "^2.0.0",
     "express": "~4.13.4",
+    "express-autoprefixer": "^5.1.0",
     "jade": "~1.11.0",
     "lodash": "^4.14.0",
     "mongoose": "^4.5.5",
     "morgan": "~1.7.0",
+    "node-sass-middleware": "^0.9.8",
     "nunjucks": "^2.4.2",
     "serve-favicon": "~2.3.0"
   },

--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -1,0 +1,1 @@
+@import 'bootstrap-sass/assets/stylesheets/bootstrap';

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,8 +1,0 @@
-body {
-  padding: 50px;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
-}
-
-a {
-  color: #00B7FF;
-}

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,5 +1,0 @@
-extends layout
-
-block content
-  h1= title
-  p Welcome to #{title}

--- a/views/layout.html
+++ b/views/layout.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Bootstrap 101 Template</title>
+
+    <!-- Bootstrap -->
+    <link href="css/style.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    {% block header %}
+    <div class="jumbotron">
+      <div class="container">
+        <h1><a href="/">CoH Music Table</a></h1>
+        <p>A shared resource of music used for worship in the Circle of Hope community.</p>
+      </div>
+    </div>
+    {% endblock %}
+    <div class="container">
+      {% block pageContent %}
+      Page Failed to Load
+      {% endblock %}
+    </div>
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="js/bootstrap.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR contains all the code required to get the SASS workflow configured, including loading Bootstrap into our layout template. Note: The layout template isn't actually in use yet, but I tested it. It will close #18.

I'm not crazy about the implementation, it feels a bit clumsy. We are loading bootstrap into our base SASS file via an `@import` to the `node_modules` folder. When our template loads the base CSS file, the SASS-middleware will automatically compile our base SASS file into that base CSS file, including all of bootstrap via the `@import`. It will also autoprefix it, since Bootstrap requires that step. 

It's hard to find resources on how people are doing this because most people use build tools, which might be the route we should go, but also most people are just including the Bootstrap CSS or writing their own, so it's hard to find the right answers. Loading SASS from npm feels a bit odd. This will work for now and if we want to change it down the road, we can do that.
